### PR TITLE
fix(android): allow debug builds without key.properties

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -41,22 +41,26 @@ android {
         multiDexEnabled = true
     }
 
-        signingConfigs {
-        create("release") {
-            keyAlias = keystoreProperties["keyAlias"] as String
-            keyPassword = keystoreProperties["keyPassword"] as String
-            storeFile = keystoreProperties["storeFile"]?.let { file(it) }
-            storePassword = keystoreProperties["storePassword"] as String
+    signingConfigs {
+        if (keystorePropertiesFile.exists()) {
+            create("release") {
+                keyAlias = keystoreProperties["keyAlias"] as String
+                keyPassword = keystoreProperties["keyPassword"] as String
+                storeFile = keystoreProperties["storeFile"]?.let { file(it) }
+                storePassword = keystoreProperties["storePassword"] as String
+            }
         }
     }
 
-
-   buildTypes {
+    buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("release")
-            // Enable code shrinking, obfuscation, and resource shrinking for release builds to reduce app size
+            // Use the release signing config when key.properties is provided,
+            // otherwise fall back to the debug signing config so contributors
+            // without a keystore can still build the project.
+            signingConfig = if (keystorePropertiesFile.exists())
+                signingConfigs.getByName("release")
+            else
+                signingConfigs.getByName("debug")
             isMinifyEnabled = true
             isShrinkResources = true
         }


### PR DESCRIPTION
## Summary

Building from a fresh clone currently fails on Android with:

> null cannot be cast to non-null type kotlin.String
> Build file 'android/app/build.gradle.kts' line: 46

The `signingConfigs.release` block unconditionally casts
`keystoreProperties[...]` to `String`. Since `key.properties` is
gitignored, any contributor cloning the repo without their own keystore
hits this — even for debug builds, where release signing isn't actually
used.

## What this PR changes

- Wraps the release signing config in a `keystorePropertiesFile.exists()`
  check so the cast only runs when a keystore is configured.
- In `buildTypes.release`, falls back to the debug signing config when no
  keystore is provided. This matches what the existing comment
  ("Signing with the debug keys for now…") said the intent already was.

For maintainers who already have `key.properties`: behaviour is
unchanged — the release signing config is created and used as before.

## Test plan

- [x] Fresh clone, no `key.properties` → `flutter run` succeeds, app
      installs and runs in debug on a real device
- [x] `flutter analyze` passes