### PR TITLE
feat(chat): allow editing user messages

### DIFF
--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -1106,6 +1106,38 @@ class ChatNotifier extends Notifier<ChatState> {
     );
   }
 
+  Future<void> editMessage(String messageId, String newContent) async {
+    final messageIndex = state.messages.indexWhere((m) => m.id == messageId);
+    if (messageIndex == -1) return;
+
+    final message = state.messages[messageIndex];
+    if (message.role != MessageRole.user) return;
+    if (newContent.trim().isEmpty) return;
+    if (newContent == message.content) return;
+
+    final attachmentPaths = message.attachmentPaths;
+
+    final messagesToRemove = state.messages.sublist(messageIndex);
+    final db = ref.read(databaseProvider);
+    for (final msg in messagesToRemove) {
+      final query = db.messageBox
+          .query(MessageEntity_.id.equals(msg.id))
+          .build();
+      db.messageBox.removeMany(query.findIds());
+      query.close();
+    }
+
+    state = state.copyWith(
+      messages: state.messages.sublist(0, messageIndex),
+      clearStreaming: true,
+    );
+
+    await sendMessage(
+      newContent,
+      attachments: attachmentPaths?.map((p) => File(p)).toList(),
+    );
+  }
+
   Future<void> _saveMessage(Message message) async {
     final db = ref.read(databaseProvider);
     final query = db.messageBox

--- a/lib/features/chat/views/chat_screen.dart
+++ b/lib/features/chat/views/chat_screen.dart
@@ -14,6 +14,7 @@ import '../data/models/message.dart';
 import '../providers/chat_providers.dart';
 import 'components/chat_bubble.dart';
 import 'components/chat_input_bar.dart';
+import 'components/edit_message_dialog.dart';
 import '../providers/chat_mcp_providers.dart';
 import 'components/chat_settings_sheet.dart';
 import 'components/notification_permission_banner.dart';
@@ -265,6 +266,17 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                   },
                   onDelete: (messageId) {
                     ref.read(chatProvider.notifier).deleteMessage(messageId);
+                  },
+                  onEdit: (messageId, currentContent) async {
+                    final newContent = await EditMessageDialog.show(
+                      context,
+                      initialContent: currentContent,
+                    );
+                    if (newContent != null && newContent != currentContent) {
+                      await ref
+                          .read(chatProvider.notifier)
+                          .editMessage(messageId, newContent);
+                    }
                   },
                   hasSmartReplies:
                       !chatState.isStreaming &&
@@ -1096,6 +1108,7 @@ class _MessageList extends StatelessWidget {
     required this.isStreaming,
     required this.onRetry,
     required this.onDelete,
+    required this.onEdit,
     this.hasSmartReplies = false,
   });
 
@@ -1105,6 +1118,7 @@ class _MessageList extends StatelessWidget {
   final bool isStreaming;
   final void Function(String) onRetry;
   final void Function(String) onDelete;
+  final void Function(String messageId, String currentContent) onEdit;
   final bool hasSmartReplies;
 
   @override
@@ -1147,6 +1161,9 @@ class _MessageList extends StatelessWidget {
               isLast && isStreaming && message.id == streamingMessage?.id,
           onRetry: () => onRetry(message.id),
           onDelete: () => onDelete(message.id),
+          onEdit: message.role == MessageRole.user
+              ? () => onEdit(message.id, message.content)
+              : null,
         );
       },
     );

--- a/lib/features/chat/views/components/edit_message_dialog.dart
+++ b/lib/features/chat/views/components/edit_message_dialog.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class EditMessageDialog extends StatefulWidget {
+  const EditMessageDialog({super.key, required this.initialContent});
+
+  final String initialContent;
+
+  static Future<String?> show(
+    BuildContext context, {
+    required String initialContent,
+  }) {
+    return showModalBottomSheet<String>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (context) => EditMessageDialog(initialContent: initialContent),
+    );
+  }
+
+  @override
+  State<EditMessageDialog> createState() => _EditMessageDialogState();
+}
+
+class _EditMessageDialogState extends State<EditMessageDialog> {
+  late final TextEditingController _controller;
+  late final FocusNode _focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialContent);
+    _focusNode = FocusNode();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _focusNode.requestFocus();
+      _controller.selection = TextSelection(
+        baseOffset: 0,
+        extentOffset: _controller.text.length,
+      );
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  void _save() {
+    final text = _controller.text.trim();
+    if (text.isEmpty) return;
+    Navigator.of(context).pop(text);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final hintColor = isDark
+        ? const Color(0xFF888888)
+        : const Color(0xFF666666);
+
+    return Material(
+      type: MaterialType.transparency,
+      child: Padding(
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.of(context).viewInsets.bottom,
+        ),
+        child: Container(
+          padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
+          decoration: BoxDecoration(
+            color: isDark ? const Color(0xFF121212) : Colors.white,
+            borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.2),
+                blurRadius: 10,
+                offset: const Offset(0, -2),
+              ),
+            ],
+          ),
+          child: SafeArea(
+            top: false,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Center(
+                  child: Container(
+                    width: 32,
+                    height: 4,
+                    decoration: BoxDecoration(
+                      color: isDark
+                          ? const Color(0xFF2A2A2A)
+                          : const Color(0xFFE5E5E5),
+                      borderRadius: BorderRadius.circular(2),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  'Edit message',
+                  style: TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
+                    color: isDark ? Colors.white : Colors.black,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                TextField(
+                  controller: _controller,
+                  focusNode: _focusNode,
+                  maxLines: 8,
+                  minLines: 3,
+                  textInputAction: TextInputAction.newline,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    contentPadding: EdgeInsets.all(12),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'Saving will remove the assistant response below and regenerate.',
+                  style: TextStyle(fontSize: 12, color: hintColor),
+                ),
+                const SizedBox(height: 16),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    ShadButton.outline(
+                      onPressed: () => Navigator.of(context).pop(),
+                      child: const Text('Cancel'),
+                    ),
+                    const SizedBox(width: 8),
+                    ShadButton(
+                      onPressed: _save,
+                      child: const Text('Save & regenerate'),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Addresses part of #4.

User messages currently can't be edited. Combined with the dictation-
friendly UX of the app, this is annoying when speech-to-text mishears
something — there's no way to fix the user prompt without retyping the
whole conversation.

This PR adds an **Edit** action on user message bubbles. Tapping it
opens a bottom sheet prefilled with the current message text.
Saving regenerates the conversation from that point: the edited message
replaces the original, the assistant response and any subsequent
messages are removed, and a new response is streamed.

The Edit button only appears on user-role bubbles. The dialog is
rendered as a bottom sheet matching the project's existing pattern
(chat_settings_sheet, model_picker_sheet, etc.), with a drag handle,
rounded top corners and proper keyboard inset handling.

## What this PR changes

- New `editMessage(messageId, newContent)` in `ChatNotifier`, mirroring
  the existing `retryMessage` pattern: validate role, remove the
  message and everything after it from state and DB, then `sendMessage`
  with the new content while preserving attachments.
- New `EditMessageDialog` widget (rendered as a bottom sheet despite
  the name, for consistency with the rest of the app).
- `chat_screen.dart`'s `_MessageList` now also passes `onEdit` down to
  `ChatBubble`. The wiring inside `MessageActionBar` and `_UserBubble`
  was already prepared — only the screen-level connection was missing.
- `onEdit` is wired only for user-role messages; assistant bubbles keep
  their existing retry/delete behaviour.

## Test plan

- [x] Tap Edit on a user message → dialog opens prefilled, content is
      fully selected for quick rewrite
- [x] Modify text, "Save & regenerate" → message updates, downstream
      messages cleared, assistant streams a new reply
- [x] Cancel without modification → no change
- [x] Empty / unchanged content → silent no-op (early return)
- [x] User message with attachments → attachments preserved
- [x] Edit during streaming → previous stream cancelled (existing
      `sendMessage` behaviour, no special handling needed)
- [x] No regression on assistant retry/delete
- [x] `flutter analyze` passes