### PR TITLE
fix: improve OpenAI Compatible mode for llama.cpp and other servers

### DIFF
--- a/lib/features/chat/data/chat_service.dart
+++ b/lib/features/chat/data/chat_service.dart
@@ -450,11 +450,21 @@ class OpenAICompatibleChatService implements ChatService {
   }) async* {
     _cancelToken = CancelToken();
 
+    final apiMessages = messages
+        .map((m) => {'role': _roleToString(m.role), 'content': m.content})
+        .toList();
+    // Strip trailing empty assistant messages to avoid "prefill incompatible
+    // with enable_thinking" errors from servers running thinking models
+    while (apiMessages.isNotEmpty &&
+        apiMessages.last['role'] == 'assistant' &&
+        (apiMessages.last['content'] == null ||
+            apiMessages.last['content']!.isEmpty)) {
+      apiMessages.removeLast();
+    }
+
     final body = {
       'model': modelId,
-      'messages': messages
-          .map((m) => {'role': _roleToString(m.role), 'content': m.content})
-          .toList(),
+      'messages': apiMessages,
       'temperature': params.temperature,
       'top_p': params.topP,
       'max_tokens': params.maxTokens,

--- a/lib/features/servers/data/server_api_service.dart
+++ b/lib/features/servers/data/server_api_service.dart
@@ -97,6 +97,15 @@ class ServerApiService {
     switch (server.type) {
       case ServerType.lmStudio:
       case ServerType.openAICompatible:
+        try {
+          await _dio.post(
+            server.loadModelEndpoint,
+            data: {'model': modelId},
+            options: Options(headers: _getAuthHeaders(server)),
+          );
+        } catch (_) {
+          // Not all OpenAI-compatible servers support this endpoint
+        }
       case ServerType.ollama:
         await _dio.post(
           server.loadModelEndpoint,
@@ -118,12 +127,16 @@ class ServerApiService {
     switch (server.type) {
       case ServerType.lmStudio:
       case ServerType.openAICompatible:
-        final response = await _dio.post(
-          server.loadModelEndpoint,
-          data: {'model': modelId, 'echo_load_config': true},
-          options: Options(headers: _getAuthHeaders(server)),
-        );
-        return response.data['instance_id'] as String?;
+        try {
+          final response = await _dio.post(
+            server.loadModelEndpoint,
+            data: {'model': modelId, 'echo_load_config': true},
+            options: Options(headers: _getAuthHeaders(server)),
+          );
+          return response.data['instance_id'] as String?;
+        } catch (_) {
+          return null;
+        }
       case ServerType.ollama:
         await _dio.post(
           server.loadModelEndpoint,
@@ -150,11 +163,15 @@ class ServerApiService {
     switch (server.type) {
       case ServerType.lmStudio:
       case ServerType.openAICompatible:
-        await _dio.post(
-          server.unloadModelEndpoint,
-          data: {'instance_id': instanceId ?? modelId},
-          options: Options(headers: _getAuthHeaders(server)),
-        );
+        try {
+          await _dio.post(
+            server.unloadModelEndpoint,
+            data: {'instance_id': instanceId ?? modelId},
+            options: Options(headers: _getAuthHeaders(server)),
+          );
+        } catch (_) {
+          // Not all OpenAI-compatible servers support this endpoint
+        }
       case ServerType.ollama:
         await _dio.post(
           server.unloadModelEndpoint,
@@ -171,9 +188,17 @@ class ServerApiService {
     final runningModels = <String>{};
     if (data['models'] != null) {
       for (final item in data['models']) {
+        final id = item['key'] as String? ??
+            item['name'] as String? ??
+            item['id'] as String? ??
+            '';
         final loadedInstances = item['loaded_instances'] as List?;
         if (loadedInstances != null && loadedInstances.isNotEmpty) {
-          runningModels.add(item['key'] as String? ?? '');
+          runningModels.add(id);
+        } else if (id.isNotEmpty) {
+          // Servers without loaded_instances (e.g. llama.cpp) always have
+          // their model running if it appears in the model list
+          runningModels.add(id);
         }
       }
     }
@@ -199,21 +224,41 @@ class ServerApiService {
 
   List<ModelInfo> _parseLMStudioModels(dynamic data, Server server) {
     final List<ModelInfo> models = [];
+
+    // Build a lookup from the OpenAI-style 'data' array for metadata
+    // that may be missing from the 'models' array (e.g. llama.cpp)
+    final Map<String, Map<String, dynamic>> metaById = {};
+    if (data['data'] != null) {
+      for (final item in data['data']) {
+        final id = item['id'] as String? ?? '';
+        if (id.isNotEmpty) {
+          metaById[id] = (item['meta'] as Map<String, dynamic>?) ?? {};
+        }
+      }
+    }
+
     if (data['models'] != null) {
       for (final item in data['models']) {
-        final id = item['key'] as String? ?? '';
+        final id = item['key'] as String? ??
+            item['name'] as String? ??
+            item['id'] as String? ??
+            '';
         final displayName = item['display_name'] as String?;
         final quantization = item['quantization'];
         final paramsString = item['params_string'] as String?;
+        final meta = metaById[id] ?? {};
 
         models.add(
           ModelInfo(
             id: id,
             name: displayName ?? _formatModelName(id),
             description: item['description'] as String?,
-            parameterCount: _parseParameterString(paramsString),
-            contextLength: item['max_context_length'] as int?,
-            fileSize: item['size_bytes'] as int?,
+            parameterCount: _parseParameterString(paramsString) ??
+                _paramCountFromMeta(meta['n_params']),
+            contextLength: item['max_context_length'] as int? ??
+                meta['n_ctx_train'] as int?,
+            fileSize: item['size_bytes'] as int? ??
+                meta['size'] as int?,
             quantization: quantization?['name'] as String?,
             architecture: item['architecture'] as String?,
             serverType: server.type,
@@ -223,6 +268,12 @@ class ServerApiService {
       }
     }
     return models;
+  }
+
+  int? _paramCountFromMeta(dynamic nParams) {
+    if (nParams == null) return null;
+    if (nParams is int) return nParams ~/ 1000000000;
+    return null;
   }
 
   List<ModelInfo> _parseOllamaModels(dynamic data, Server server) {


### PR DESCRIPTION
## Summary

- Fall back to `name` or `id` when `key` is missing in model list response, supporting llama.cpp and other OpenAI-compatible servers
- Enrich model metadata from OpenAI-style `data` array when LM Studio fields are absent (context length, file size, parameter count)
- Make model load/unload endpoints non-fatal for OpenAI Compatible since many servers don't implement `/v1/models/load` or `/v1/models/unload`
- Treat models as running when `loaded_instances` is absent, since servers like llama.cpp always have their model loaded
- Strip trailing empty assistant messages before sending to avoid "prefill incompatible with enable_thinking" errors from servers running thinking models (e.g. Qwen3, DeepSeek-R1)

## Context

The "OpenAI Compatible" server type currently assumes LM Studio-specific response fields and endpoints. This breaks when connecting to llama.cpp's native `/v1/` API (and likely other OpenAI-compatible servers like vLLM, TabbyAPI, etc.):

1. **Model listing fails silently** — llama.cpp returns `name` instead of `key` in the models array, resulting in empty model IDs
2. **Model selection fails** — `/v1/models/load` returns 404, which the app treats as a hard error
3. **Chat fails with thinking models** — previous failed responses are sent as `{"role": "assistant", "content": ""}`, which triggers a 400 error ("prefill incompatible with enable_thinking") on servers running Qwen3, DeepSeek-R1, etc.

These changes make the OpenAI Compatible mode work with llama.cpp out of the box while remaining fully backwards-compatible with LM Studio.