### PR TITLE
fix: correctly resolve Traditional Chinese locale

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -9,9 +9,9 @@ import 'core/models/enums.dart';
 import 'core/providers/app_providers.dart';
 import 'core/routes/app_routes.dart';
 import 'core/theme/app_theme.dart';
+import 'core/utils/locale_utils.dart';
 import 'features/chat/providers/chat_providers.dart';
-import 'features/conversations/providers/conversation_providers.dart'
-    as conv;
+import 'features/conversations/providers/conversation_providers.dart' as conv;
 import 'features/chat/views/chat_screen.dart';
 import 'features/conversations/views/chat_history_screen.dart';
 import 'features/mcp/views/mcp_tools_screen.dart';
@@ -189,6 +189,10 @@ class App extends ConsumerWidget {
     final router = ref.watch(routerProvider);
     final appThemeType = ref.watch(themeModeProvider);
     final localeCode = ref.watch(settingsProvider.select((s) => s.localeCode));
+    final selectedLocale = findSupportedLocale(
+      localeCode,
+      AppLocalizations.supportedLocales,
+    );
 
     ThemeData theme = AppTheme.lightTheme;
     ThemeData darkTheme = AppTheme.darkTheme;
@@ -238,22 +242,11 @@ class App extends ConsumerWidget {
             GlobalWidgetsLocalizations.delegate,
             GlobalCupertinoLocalizations.delegate,
           ],
-          supportedLocales: const [
-            Locale('en'),
-            Locale('ar'),
-            Locale('bn'),
-            Locale('zh'),
-            Locale('es'),
-            Locale('hi'),
-            Locale('it'),
-            Locale('ja'),
-            Locale('ru'),
-          ],
-          locale: localeCode != null ? Locale(localeCode) : null,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: selectedLocale,
           localeResolutionCallback: (locale, supportedLocales) {
-            if (localeCode != null) {
-              final langLocale = Locale(localeCode);
-              if (supportedLocales.contains(langLocale)) return langLocale;
+            if (selectedLocale != null) {
+              return selectedLocale;
             }
             for (final l in supportedLocales) {
               if (l.languageCode == locale?.languageCode) return l;
@@ -323,18 +316,13 @@ class AppShell extends ConsumerWidget {
                         ? const Color(0xFF1A1A1A)
                         : const Color(0xFFE5E5E5),
                   ),
-                  Expanded(
-                    child: child,
-                  ),
+                  Expanded(child: child),
                 ],
               ),
             );
           }
 
-          return Scaffold(
-            body: child,
-            drawer: const ConversationDrawer(),
-          );
+          return Scaffold(body: child, drawer: const ConversationDrawer());
         },
       ),
     );

--- a/lib/bootstrap/bootstrap_host.dart
+++ b/lib/bootstrap/bootstrap_host.dart
@@ -14,6 +14,7 @@ import '../core/models/enums.dart';
 import '../features/servers/data/models/server.dart';
 import '../features/servers/providers/server_providers.dart';
 import '../core/logger/app_logger.dart';
+import '../core/utils/locale_utils.dart';
 import 'bootstrap_screen.dart';
 import 'bootstrap_state.dart';
 
@@ -55,7 +56,7 @@ class _BootstrapHostState extends State<BootstrapHost> {
         if (settingsJson != null) {
           final settings = json.decode(settingsJson) as Map<String, dynamic>;
           final code = settings['localeCode'] as String?;
-          if (code != null) _savedLocale = Locale(code);
+          _savedLocale = parseLocaleCode(code);
         }
       } catch (_) {}
 
@@ -66,7 +67,10 @@ class _BootstrapHostState extends State<BootstrapHost> {
         ],
       );
 
-      _updateStage(BootstrapStage.initializingServices, 'Initializing services...');
+      _updateStage(
+        BootstrapStage.initializingServices,
+        'Initializing services...',
+      );
 
       final hfToken = container.read(
         settingsProvider.select((s) => s.huggingFaceToken),

--- a/lib/core/utils/locale_utils.dart
+++ b/lib/core/utils/locale_utils.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+Locale? parseLocaleCode(String? localeCode) {
+  if (localeCode == null) {
+    return null;
+  }
+
+  final normalized = localeCode.trim().replaceAll('-', '_');
+  if (normalized.isEmpty) {
+    return null;
+  }
+
+  final parts = normalized.split('_');
+  final languageCode = parts.first.toLowerCase();
+
+  if (parts.length == 1) {
+    return Locale(languageCode);
+  }
+
+  final secondPart = parts[1];
+  final scriptCode = secondPart.length == 4 ? secondPart : null;
+  final countryCode = scriptCode == null ? secondPart.toUpperCase() : null;
+  final resolvedCountryCode = parts.length > 2
+      ? parts[2].toUpperCase()
+      : countryCode;
+
+  return Locale.fromSubtags(
+    languageCode: languageCode,
+    scriptCode: scriptCode,
+    countryCode: resolvedCountryCode,
+  );
+}
+
+Locale? findSupportedLocale(
+  String? localeCode,
+  Iterable<Locale> supportedLocales,
+) {
+  final parsedLocale = parseLocaleCode(localeCode);
+  if (parsedLocale == null) {
+    return null;
+  }
+
+  for (final locale in supportedLocales) {
+    if (_sameLocale(locale, parsedLocale)) {
+      return locale;
+    }
+  }
+
+  for (final locale in supportedLocales) {
+    if (locale.languageCode == parsedLocale.languageCode) {
+      return locale;
+    }
+  }
+
+  return null;
+}
+
+bool _sameLocale(Locale a, Locale b) {
+  return a.languageCode == b.languageCode &&
+      (a.scriptCode ?? '') == (b.scriptCode ?? '') &&
+      (a.countryCode ?? '') == (b.countryCode ?? '');
+}

--- a/lib/features/onboarding/screens/onboarding_language_screen.dart
+++ b/lib/features/onboarding/screens/onboarding_language_screen.dart
@@ -73,6 +73,16 @@ const _languages = [
     gradient: [Color(0xFFEF4444), Color(0xFFDC2626)],
   ),
   _LanguageOption(
+    code: 'zh_TW',
+    nativeName: '繁體中文',
+    englishName: 'Traditional Chinese',
+    flag: '🇹🇼',
+    flagAsset: 'assets/images/flag_tw.png',
+    countryCode: 'TW',
+    shortText: 'Zh-TW',
+    gradient: [Color(0xFF2563EB), Color(0xFF1D4ED8)],
+  ),
+  _LanguageOption(
     code: 'ar',
     nativeName: 'العربية',
     englishName: 'Arabic',
@@ -153,7 +163,6 @@ class _OnboardingLanguageScreenState
     final l10n = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
 
-
     return Scaffold(
       appBar: AppBar(
         title: Row(
@@ -198,10 +207,7 @@ class _OnboardingLanguageScreenState
                   children: [
                     const SizedBox(height: 24),
                     Actor(
-                      acts: [
-                        .fadeIn(),
-                        .slideY(from: 0.08),
-                      ],
+                      acts: [.fadeIn(), .slideY(from: 0.08)],
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.stretch,
                         children: [
@@ -227,7 +233,9 @@ class _OnboardingLanguageScreenState
                             l10n.onboarding_choose_language_desc,
                             textAlign: TextAlign.center,
                             style: theme.textTheme.bodySmall?.copyWith(
-                              color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+                              color: theme.colorScheme.onSurface.withValues(
+                                alpha: 0.7,
+                              ),
                               height: 1.5,
                             ),
                           ),
@@ -237,15 +245,13 @@ class _OnboardingLanguageScreenState
                     const SizedBox(height: 32),
                     Actor(
                       delay: 60.ms,
-                      acts: [
-                        .fadeIn(),
-                        .slideY(from: 0.08),
-                      ],
+                      acts: [.fadeIn(), .slideY(from: 0.08)],
                       child: ListView.separated(
                         shrinkWrap: true,
                         physics: const NeverScrollableScrollPhysics(),
                         itemCount: _languages.length,
-                        separatorBuilder: (context, index) => const SizedBox(height: 12),
+                        separatorBuilder: (context, index) =>
+                            const SizedBox(height: 12),
                         itemBuilder: (context, index) {
                           final lang = _languages[index];
                           final isSelected = _selectedCode == lang.code;
@@ -272,8 +278,9 @@ class _OnboardingLanguageScreenState
                                 border: Border.all(
                                   color: isSelected
                                       ? theme.colorScheme.primary
-                                      : theme.colorScheme.outline
-                                          .withValues(alpha: 0.15),
+                                      : theme.colorScheme.outline.withValues(
+                                          alpha: 0.15,
+                                        ),
                                   width: isSelected ? 2 : 1,
                                 ),
                                 boxShadow: isSelected
@@ -283,7 +290,7 @@ class _OnboardingLanguageScreenState
                                               .withValues(alpha: 0.1),
                                           blurRadius: 8,
                                           offset: const Offset(0, 2),
-                                        )
+                                        ),
                                       ]
                                     : null,
                               ),
@@ -302,7 +309,9 @@ class _OnboardingLanguageScreenState
                                       ),
                                       boxShadow: [
                                         BoxShadow(
-                                          color: Colors.black.withValues(alpha: 0.05),
+                                          color: Colors.black.withValues(
+                                            alpha: 0.05,
+                                          ),
                                           blurRadius: 4,
                                           offset: const Offset(0, 2),
                                         ),
@@ -316,35 +325,42 @@ class _OnboardingLanguageScreenState
                                         width: 48,
                                         height: 32,
                                         fit: BoxFit.cover,
-                                        errorBuilder: (context, error, stackTrace) {
-                                          return Text(
-                                            lang.flag,
-                                            style: const TextStyle(fontSize: 18),
-                                          );
-                                        },
+                                        errorBuilder:
+                                            (context, error, stackTrace) {
+                                              return Text(
+                                                lang.flag,
+                                                style: const TextStyle(
+                                                  fontSize: 18,
+                                                ),
+                                              );
+                                            },
                                       ),
                                     ),
                                   ),
                                   const SizedBox(width: 16),
                                   Expanded(
                                     child: Column(
-                                      crossAxisAlignment: CrossAxisAlignment.start,
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
                                       mainAxisSize: MainAxisSize.min,
                                       children: [
                                         Text(
                                           lang.nativeName,
-                                          style:
-                                              theme.textTheme.titleMedium?.copyWith(
-                                            fontWeight: FontWeight.bold,
-                                          ),
+                                          style: theme.textTheme.titleMedium
+                                              ?.copyWith(
+                                                fontWeight: FontWeight.bold,
+                                              ),
                                         ),
                                         const SizedBox(height: 2),
                                         Text(
                                           '${lang.englishName} • ${lang.shortText.toUpperCase()}',
-                                          style: theme.textTheme.labelSmall?.copyWith(
-                                            color: theme.colorScheme.onSurface
-                                                .withValues(alpha: 0.5),
-                                          ),
+                                          style: theme.textTheme.labelSmall
+                                              ?.copyWith(
+                                                color: theme
+                                                    .colorScheme
+                                                    .onSurface
+                                                    .withValues(alpha: 0.5),
+                                              ),
                                         ),
                                       ],
                                     ),
@@ -363,13 +379,13 @@ class _OnboardingLanguageScreenState
                                         color: isSelected
                                             ? theme.colorScheme.primary
                                             : theme.colorScheme.outline
-                                                .withValues(alpha: 0.3),
+                                                  .withValues(alpha: 0.3),
                                         width: 2,
                                       ),
                                     ),
                                     child: isSelected
-                                        ? const HugeIcon(icon: 
-                                            HugeIcons.strokeRoundedTick01,
+                                        ? const HugeIcon(
+                                            icon: HugeIcons.strokeRoundedTick01,
                                             color: Colors.white,
                                             size: 14,
                                           )
@@ -389,10 +405,7 @@ class _OnboardingLanguageScreenState
             ),
             Actor(
               delay: 120.ms,
-              acts: [
-                .fadeIn(),
-                .slideY(from: 0.08),
-              ],
+              acts: [.fadeIn(), .slideY(from: 0.08)],
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 24.0),
                 child: Column(
@@ -435,9 +448,7 @@ class _OnboardingLanguageScreenState
                         ),
                       ),
                     ),
-                    SizedBox(
-                      height: MediaQuery.of(context).padding.bottom,
-                    ),
+                    SizedBox(height: MediaQuery.of(context).padding.bottom),
                   ],
                 ),
               ),

--- a/test/core/utils/locale_utils_test.dart
+++ b/test/core/utils/locale_utils_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:localmind/core/utils/locale_utils.dart';
+import 'package:localmind/l10n/app_localizations.dart';
+
+void main() {
+  group('parseLocaleCode', () {
+    test('parses language only locales', () {
+      expect(parseLocaleCode('zh'), const Locale('zh'));
+    });
+
+    test('parses locales with country codes', () {
+      expect(parseLocaleCode('zh_TW'), const Locale('zh', 'TW'));
+      expect(parseLocaleCode('zh-TW'), const Locale('zh', 'TW'));
+    });
+  });
+
+  group('findSupportedLocale', () {
+    test('matches Traditional Chinese exactly', () {
+      expect(
+        findSupportedLocale('zh_TW', AppLocalizations.supportedLocales),
+        const Locale('zh', 'TW'),
+      );
+    });
+
+    test('falls back to language-only locale when region is unsupported', () {
+      expect(
+        findSupportedLocale('zh_HK', AppLocalizations.supportedLocales),
+        const Locale('zh'),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Fix Traditional Chinese locale resolution

- add locale parsing utility for values like `zh_TW`
- use `AppLocalizations.supportedLocales` instead of a partial hardcoded list
- restore saved locale correctly during bootstrap
- add Traditional Chinese option in onboarding
- add tests for locale parsing and supported locale matching

This fixes the issue where Traditional Chinese translations existed in the repo
but the app still fell back to English because `zh_TW` was not being resolved
to `Locale('zh', 'TW')`.
<img width="1200" height="2670" alt="Screenshot_2026-07-10-04-21-35-033_pro momin localmind" src="https://github.com/user-attachments/assets/cbeb54bb-80b2-4505-b9eb-9a8ffa1161dc" />
<img width="1200" height="2670" alt="Screenshot_2026-07-10-04-21-44-872_pro momin localmind" src="https://github.com/user-attachments/assets/436dcc61-bdec-4f61-b186-93cc5bc267f9" />
