### PR TITLE
chore: mark Android Assistant integration as beta

### DIFF
--- a/lib/features/settings/views/settings_screen.dart
+++ b/lib/features/settings/views/settings_screen.dart
@@ -218,6 +218,7 @@ class SettingsViews extends ConsumerWidget {
                       title: l10n.settings_android_assistant,
                       icon: HugeIcons.strokeRoundedVoice,
                       accent: const Color(0xFF6366F1),
+                      badges: [_FeatureBadge(label: l10n.beta_label)],
                       children: const [_AndroidAssistantSetting()],
                     )
                   : null;
@@ -942,12 +943,14 @@ class _SettingsSectionCard extends StatelessWidget {
     required this.icon,
     required this.accent,
     required this.children,
+    this.badges = const [],
   });
 
   final String title;
   final List<List<dynamic>> icon;
   final Color accent;
   final List<Widget> children;
+  final List<Widget> badges;
 
   @override
   Widget build(BuildContext context) {
@@ -984,6 +987,7 @@ class _SettingsSectionCard extends StatelessWidget {
                     ),
                   ),
                 ),
+                if (badges.isNotEmpty) ...[const SizedBox(width: 8), ...badges],
               ],
             ),
             const SizedBox(height: 12),


### PR DESCRIPTION
## Summary
- display a localized Beta badge on the Android Assistant settings section
- keep the status and role-selection controls unchanged
- identify the system-assistant integration as a preview while device coverage is expanded

## Validation
- fvm flutter analyze
- fvm flutter test test/core/services/android_assistant_service_test.dart test/app_shell_back_navigation_test.dart

Follow-up to #37.